### PR TITLE
Fetch and display file structure

### DIFF
--- a/.github/workflows/azure-static-web-apps-salmon-coast-020df5910.yml
+++ b/.github/workflows/azure-static-web-apps-salmon-coast-020df5910.yml
@@ -23,17 +23,23 @@ jobs:
           submodules: true
           lfs: false
 
-      # ✅ This step ensures Node 20 is used
-      - name: Use Node.js 20
+      # ✅ Ensure Node 22 is used for install/build
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.x
+
+      - name: Install dependencies and build (restaurant-app)
+        working-directory: restaurant-app
+        run: |
+          npm ci
+          npm run build
 
       - name: Install OIDC Client from Core Package
         run: npm install @actions/core@1.6.0 @actions/http-client
 
       - name: Get Id Token
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: idtoken
         with:
            script: |
@@ -49,7 +55,8 @@ jobs:
           action: "upload"
           app_location: "./restaurant-app" # App source code path
           api_location: "" # Api source code path - optional
-          output_location: "build" # Built app content directory - optional
+          output_location: "dist" # Built app content directory relative to app_location
+          skip_app_build: true
           github_id_token: ${{ steps.idtoken.outputs.result }}
 
   close_pull_request_job:


### PR DESCRIPTION
Update CI workflow to use Node 22 and explicitly build `restaurant-app`.

This PR fixes CI build failures by upgrading the Node.js version to 22.x in the GitHub Actions workflow, adding explicit build steps for the `restaurant-app`, and configuring the Static Web Apps action to use the pre-built `dist` directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-06f649d7-a852-4ee2-9134-93876862af32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-06f649d7-a852-4ee2-9134-93876862af32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

